### PR TITLE
hotfix: remove forgotten snackbar from news screen (refactor)

### DIFF
--- a/app/src/main/java/com/example/elongaassignmentapp/MainActivity.kt
+++ b/app/src/main/java/com/example/elongaassignmentapp/MainActivity.kt
@@ -99,7 +99,7 @@ fun AppNavigation(
 ) {
     NavHost(navController = navController, startDestination = Route.Login, modifier = modifier) {
         composable<Route.Login> { LoginScreen(navController) }
-        composable<Route.News> { NewsScreen(navController, snackbarHostState) }
+        composable<Route.News> { NewsScreen(navController) }
         composable<Route.Article> { navBackStackEntry ->
             val article: Route.Article = navBackStackEntry.toRoute()
             ArticleScreen(navController, snackbarHostState, article.articleId)

--- a/app/src/main/java/com/example/elongaassignmentapp/ui/screen/news/NewsScreen.kt
+++ b/app/src/main/java/com/example/elongaassignmentapp/ui/screen/news/NewsScreen.kt
@@ -1,37 +1,19 @@
 package com.example.elongaassignmentapp.ui.screen.news
 
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.NavController
 import com.example.elongaassignmentapp.Route
-import com.example.elongaassignmentapp.ui.screen.news.model.NewsUIEvent
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun NewsScreen(
     navController: NavController,
-    snackbarHostState: SnackbarHostState,
 ) {
     val viewModel: NewsViewModel = koinViewModel()
 
     LaunchedEffect(Unit) {
         viewModel.onScreenLaunched()
-        viewModel.oneTimeEvent.collect { event ->
-            when (event) {
-                is NewsUIEvent.ShowSnackbar -> {
-                    val snackbarResult = snackbarHostState.showSnackbar(
-                        message = event.message,
-                        actionLabel = "Try again",
-                    )
-                    when (snackbarResult) {
-                        SnackbarResult.ActionPerformed -> { viewModel.onRefresh() }
-                        SnackbarResult.Dismissed -> {}
-                    }
-                }
-            }
-        }
     }
 
     NewsScreenLayout(

--- a/app/src/main/java/com/example/elongaassignmentapp/ui/screen/news/NewsViewModel.kt
+++ b/app/src/main/java/com/example/elongaassignmentapp/ui/screen/news/NewsViewModel.kt
@@ -8,42 +8,30 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import com.example.elongaassignmentapp.data.repository.AuthRepository
 import com.example.elongaassignmentapp.data.repository.NewsRepository
-import com.example.elongaassignmentapp.ui.screen.news.model.NewsUIEvent
 import com.example.elongaassignmentapp.ui.screen.news.model.NewsUIState
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 
 abstract class NewsViewModel : ViewModel() {
     abstract val uiState: NewsUIState
-    abstract val oneTimeEvent: SharedFlow<NewsUIEvent>
     abstract fun onScreenLaunched()
-    abstract fun onRefresh()
 }
 
 class NewsViewModelImpl(
     private val authRepository: AuthRepository,
-    private val newsRepository: NewsRepository,
+    newsRepository: NewsRepository,
 ) : NewsViewModel() {
     override var uiState by mutableStateOf<NewsUIState>(NewsUIState.Idle)
         private set
-
-    // Expose SharedFlow for one-time events
-    private val _oneTimeEvent = MutableSharedFlow<NewsUIEvent>()
-    override val oneTimeEvent: SharedFlow<NewsUIEvent> = _oneTimeEvent.asSharedFlow()
 
     // Main data flow for this screen
     private val _latestNews = newsRepository.getLatestNewsFlow().cachedIn(viewModelScope)
 
     override fun onScreenLaunched() {
-        refreshNews()
+        initState()
     }
 
-    override fun onRefresh() = refreshNews()
-
-    private fun refreshNews() {
+    private fun initState() {
         viewModelScope.launch(Dispatchers.IO) {
             uiState = if (authRepository.isAuthorized()) {
                 NewsUIState.ShowContent(_latestNews)

--- a/app/src/main/java/com/example/elongaassignmentapp/ui/screen/news/model/NewsUIEvent.kt
+++ b/app/src/main/java/com/example/elongaassignmentapp/ui/screen/news/model/NewsUIEvent.kt
@@ -1,5 +1,0 @@
-package com.example.elongaassignmentapp.ui.screen.news.model
-
-sealed class NewsUIEvent {
-    data class ShowSnackbar(val message: String) : NewsUIEvent()
-}


### PR DESCRIPTION
only refactor, nothing should be added or removed